### PR TITLE
Fix extra overwritten issue

### DIFF
--- a/lib/src/dio_http_formatter_base.dart
+++ b/lib/src/dio_http_formatter_base.dart
@@ -5,7 +5,8 @@ import 'package:logger/logger.dart';
 
 typedef HttpLoggerFilter = bool Function();
 
-const _startTimeKey = ' dio_http_formatter@start_time';
+const _prefix = 'dio_http_formatter';
+const _startTimeKey = '$_prefix@start_time';
 
 class HttpFormatter extends Interceptor {
   // Logger object to pretty print the HTTP Request

--- a/lib/src/dio_http_formatter_base.dart
+++ b/lib/src/dio_http_formatter_base.dart
@@ -5,6 +5,8 @@ import 'package:logger/logger.dart';
 
 typedef HttpLoggerFilter = bool Function();
 
+const _startTimeKey = ' dio_http_formatter@start_time';
+
 class HttpFormatter extends Interceptor {
   // Logger object to pretty print the HTTP Request
   final Logger _logger;
@@ -48,9 +50,7 @@ class HttpFormatter extends Interceptor {
 
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    options.extra = <String, dynamic>{
-      'start_time': DateTime.now().millisecondsSinceEpoch
-    };
+    options.extra[_startTimeKey] = DateTime.now().millisecondsSinceEpoch;
     super.onRequest(options, handler);
   }
 
@@ -142,7 +142,7 @@ class HttpFormatter extends Interceptor {
     if (_includeResponse && response != null) {
       responseString =
           '⤵ RESPONSE [${response.statusCode}/${response.statusMessage}] '
-          '${requestOptions?.extra['start_time'] != null ? '[Time elapsed: ${DateTime.now().millisecondsSinceEpoch - requestOptions?.extra['start_time']} ms]' : ''}'
+          '${requestOptions?.extra[_startTimeKey] != null ? '[Time elapsed: ${DateTime.now().millisecondsSinceEpoch - requestOptions?.extra[_startTimeKey]} ms]' : ''}'
           '⤵\n\n';
 
       if (_includeResponseHeaders) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dio_http_formatter
 description: A Dio interceptor for pretty printing the HTTP request/response to be printed in the console for easier debugging
-version: 2.1.0
+version: 2.1.1
 repository: https://github.com/assemmarwan/dio_http_formatter
 homepage: https://github.com/assemmarwan/dio_http_formatter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dio_http_formatter
 description: A Dio interceptor for pretty printing the HTTP request/response to be printed in the console for easier debugging
-version: 2.1.1
+version: 2.1.0
 repository: https://github.com/assemmarwan/dio_http_formatter
 homepage: https://github.com/assemmarwan/dio_http_formatter
 


### PR DESCRIPTION
Extra should not be overwritten, otherwise some libraries that also run based on extra will have problems.

Such as [dio_cache_interceptor](https://github.com/llfbandit/dio_cache_interceptor/blob/ed59e98fe423e3ebba45fe7f682866563ec869ba/dio_cache_interceptor/lib/src/model/cache_options.dart#L98)