### PR TITLE
Upgrade Dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,47 @@
+## 3.0.0-preview.1
+
+### Breaking Changes
+
+- Upgrade dio to 5.0.0
+
+> Note: To use this package with dio 4.0.0, use version 2.x.x
+
+### Refactors
+
+- Use string interpolation instead of string concatenation
+
+### Chores
+
+- Use `lints` in favor of `pedantic`
+- Update dependencies
+    - logger (1.0.0 --> 1.2.0)
+    - dio (4.0.0 --> 5.0.0)
+- Include Dio version map in README
+
 ## 2.1.1
+
 - fix: Avoid replacing `extra` property of options (#6)
 
 ## 2.1.0
+
 - feat: Ability to print query parameters (Enabled by default: `includeRequestQueryParams` )
 - docs: Added example of query parameters print output
 
 ## 2.0.1
+
 - Fixed parsing request/response to String
 - Fixed handling of JSON response if List
 
 ## 2.0.0
+
 - Fully migrated to Null Safety
 
 ## 2.0.0-nullsafety.0
+
 - Migration to Null Safety
 
-
 ## 1.0.3
+
 - Added validation for empty body  ([#1](https://github.com/assemmarwan/dio_http_formatter/pull/1))
 
 ## 1.0.2

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 [![Pub Version](https://img.shields.io/pub/v/dio_http_formatter)](https://pub.dev/packages/dio_http_formatter)
 
-A simple Dio interceptor for pretty printing the HTTP request/response (using the awesome package [Logger](https://github.com/leisim/logger)) to be printed in the console for easier debugging and sharing.
+A simple Dio interceptor for pretty printing the HTTP request/response (using the awesome
+package [Logger](https://github.com/leisim/logger)) to be printed in the console for easier debugging and sharing.
 
 Different content types are supported and pretty printed such as:
+
 - `application/json`
 - `application/x-www-form-urlencoded`
 - `text/html`
@@ -16,6 +18,7 @@ flutter pub get dio_http_formatter
 ```
 
 or if not for Flutter:
+
 ```
 pub get dio_http_formatter
 ```
@@ -23,24 +26,34 @@ pub get dio_http_formatter
 2- Add the interceptor to your Dio instance like:
 
 ```dart
+
 final _dio = Dio();
 _dio.interceptors.add(HttpFormatter());
 ```
+
+### Dio Version Map
+
+For a certain version of Dio, use the following table to find the correct version of this package to use:
+
+| Dio Version | Package Version |
+|:------------|:----------------|
+| 4.x.x       | 2.x.x           |
+| 5.x.x       | 3.x.x           |
 
 ## Options
 
 Below are the optional parameters that can be specified for the formatter to customize what and how the HTTP request and response is printed.
 
-| Property                  | Type     | Default Value      |
-|:--------------------------|:---------|:------------------:|
-| includeRequest            | `bool`   | `true`             |
-| includeRequestHeaders     | `bool`   | `true`             |
-| includeRequestQueryParams | `bool`   | `true`             |
-| includeRequestBody        | `bool`   | `true`             |
-| includeResponse           | `bool`   | `true`             |
-| includeResponseHeaders    | `bool`   | `true`             |
-| includeResponseBody       | `bool`   | `true`             |
-| logger                    | `Logger` | `PrettyPrinter()`  |
+| Property                  | Type     |   Default Value   |
+|:--------------------------|:---------|:-----------------:|
+| includeRequest            | `bool`   |      `true`       |
+| includeRequestHeaders     | `bool`   |      `true`       |
+| includeRequestQueryParams | `bool`   |      `true`       |
+| includeRequestBody        | `bool`   |      `true`       |
+| includeResponse           | `bool`   |      `true`       |
+| includeResponseHeaders    | `bool`   |      `true`       |
+| includeResponseBody       | `bool`   |      `true`       |
+| logger                    | `Logger` | `PrettyPrinter()` |
 
 ## Examples
 
@@ -112,7 +125,6 @@ Below are the optional parameters that can be specified for the formatter to cus
 ```dart
 await _dio.get('https://example.org');
 ```
-
 
 ```
 ┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -188,14 +200,12 @@ await _dio.get('https://example.org');
 └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 ```
 
-
 ### Successful GET request with Query Params [text/html]
 
 ```dart
   await _dio.get('https://example.com',
         queryParameters: {'limit_start': 0, 'search_term': 'dart'});
 ```
-
 
 ```
 ┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,7 @@
 # Defines a default set of lint rules enforced for
 # projects at Google. For details and rationale,
 # see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/lib/src/dio_http_formatter_base.dart
+++ b/lib/src/dio_http_formatter_base.dart
@@ -129,12 +129,12 @@ class HttpFormatter extends Interceptor {
       if (_includeRequestQueryParams &&
           requestOptions?.queryParameters != null &&
           requestOptions!.queryParameters.isNotEmpty) {
-        requestString += '\n' + _getQueryParams(requestOptions.queryParameters);
+        requestString += '\n${_getQueryParams(requestOptions.queryParameters)}';
       }
 
       if (_includeRequestBody && requestOptions?.data != null) {
-        requestString += '\n\n' +
-            _getBody(requestOptions?.data, requestOptions?.contentType);
+        requestString +=
+            '\n\n${_getBody(requestOptions?.data, requestOptions?.contentType)}';
       }
 
       requestString += '\n\n';
@@ -153,8 +153,8 @@ class HttpFormatter extends Interceptor {
       }
 
       if (_includeResponseBody && response.data != null) {
-        responseString += '\n\n' +
-            _getBody(response.data, response.headers.value('content-type'));
+        responseString +=
+            '\n\n${_getBody(response.data, response.headers.value('content-type'))}';
       }
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  dio: ^4.0.0
-  logger: ^1.0.0
+  dio: ^5.0.0
+  logger: ^1.2.0
 
 dev_dependencies:
   pedantic: ^1.11.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dio_http_formatter
 description: A Dio interceptor for pretty printing the HTTP request/response to be printed in the console for easier debugging
-version: 2.1.1
+version: 3.0.0-preview.1
 repository: https://github.com/assemmarwan/dio_http_formatter
 homepage: https://github.com/assemmarwan/dio_http_formatter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,5 +12,5 @@ dependencies:
   logger: ^1.2.0
 
 dev_dependencies:
-  pedantic: ^1.11.1
+  lints: ^2.0.0
   test: ^1.16.5


### PR DESCRIPTION
### Breaking Changes

- Upgrade dio to 5.0.0

### Refactors

- Use string interpolation instead of string concatenation

### Chores

- Use `lints` in favor of `pedantic`
- Update dependencies
    - logger (1.0.0 --> 1.2.0)
    - dio (4.0.0 --> 5.0.0)
- Include Dio version map in README